### PR TITLE
Fix flow bugs, eliminate infinite loop risks, and reduce latency

### DIFF
--- a/surfsense_backend/app/agents/new_chat/nodes/executor.py
+++ b/surfsense_backend/app/agents/new_chat/nodes/executor.py
@@ -117,7 +117,7 @@ def _normalize_messages_for_provider_compat(messages: list[Any]) -> list[Any]:
     Avoid NullValue in content/tool-call fields between turns.
     """
     normalized_messages: list[Any] = []
-    for message in messages:
+    for idx, message in enumerate(messages):
         if isinstance(message, AIMessage):
             content = _normalize_message_content(getattr(message, "content", ""))
             raw_tool_calls = getattr(message, "tool_calls", None)

--- a/surfsense_backend/app/agents/new_chat/nodes/intent.py
+++ b/surfsense_backend/app/agents/new_chat/nodes/intent.py
@@ -435,6 +435,7 @@ def build_intent_resolver_node(
             updates["agent_hops"] = 0
             updates["no_progress_runs"] = 0
             updates["guard_parallel_preview"] = []
+            updates["subagent_handoffs"] = []
             updates["graph_complexity"] = graph_complexity
             updates["speculative_candidates"] = speculative_candidates
             updates["speculative_results"] = {}

--- a/surfsense_backend/app/agents/new_chat/supervisor_constants.py
+++ b/surfsense_backend/app/agents/new_chat/supervisor_constants.py
@@ -211,7 +211,7 @@ _LOOP_GUARD_TOOL_NAMES = {
     "reflect_on_progress",
     "write_todos",
 }
-_LOOP_GUARD_MAX_CONSECUTIVE = 12
+_LOOP_GUARD_MAX_CONSECUTIVE = 4  # Was 12 — unreachable given _MAX_AGENT_HOPS_PER_TURN=3
 _MAX_AGENT_HOPS_PER_TURN = 3
 _SANDBOX_CODE_TOOL_IDS = (
     "sandbox_write_file",

--- a/surfsense_backend/app/agents/new_chat/supervisor_pipeline_prompts.py
+++ b/surfsense_backend/app/agents/new_chat/supervisor_pipeline_prompts.py
@@ -54,7 +54,6 @@ Regler:
 - Ett steg = en konkret delegerbar aktivitet.
 - **VIKTIGT: Använd ENDAST de agenter som redan finns i `selected_agents`. Lägg INTE till fler agenter.**
 - Om en specialiserad agent (marketplace, statistics, weather, etc.) är vald, använd ENDAST den agenten.
-- For mixade fragor: skapa parallella steg, ett per sub_intent/agent.
 - Om anvandaren explicit ber om att lasa filinnehall: lagg in ett steg som faktiskt laser filen
   (sandbox_read_file) innan slutsats.
 - Foredra artifact-first: stora mellanresultat ska kunna refereras via artifact path/uri.

--- a/surfsense_backend/app/agents/new_chat/supervisor_types.py
+++ b/surfsense_backend/app/agents/new_chat/supervisor_types.py
@@ -29,12 +29,14 @@ def _append_compare_outputs(
     merged: dict[str, dict[str, Any]] = {}
     for item in left or []:
         tool_call_id = str(item.get("tool_call_id") or "")
-        if tool_call_id:
-            merged[tool_call_id] = item
+        # Fall back to a positional key so items without an explicit ID are
+        # not silently dropped (e.g. timeout results, Tavily error responses).
+        key = tool_call_id or f"__idx_{len(merged)}"
+        merged[key] = item
     for item in right or []:
         tool_call_id = str(item.get("tool_call_id") or "")
-        if tool_call_id:
-            merged[tool_call_id] = item
+        key = tool_call_id or f"__idx_{len(merged)}"
+        merged[key] = item
     return list(merged.values())
 
 


### PR DESCRIPTION
Bugfixes:
- executor.py: fix NameError — loop variable `idx` was undefined in _normalize_messages_for_provider_compat (used enumerate to introduce it).
- smart_critic.py: do not replan when final_response already exists; the previous code set final_response=None and requested replan even when a valid partial answer was available, discarding correct responses.
- supervisor_types.py: _append_compare_outputs now assigns a positional key (f"__idx_N") for outputs without a tool_call_id instead of silently dropping them (affected timeout results and Tavily error responses in compare mode).

Infinite loop prevention:
- supervisor_agent.py critic_should_continue: changed the final fallback from return "planner" to return "synthesis_hitl". The old code re-entered the planner unconditionally when replan budget was exhausted and guard-message rendering returned an empty string, creating a true infinite loop. Synthesis is always the correct exit path at that point.
- supervisor_agent.py route_after_intent: add return END for unknown/stale pending_hitl_stage values. Previously the graph would silently fall through to normal routing while awaiting_confirmation was True, executing plan steps without user approval. Also added END to resolve_intent_paths.

State correctness:
- intent.py: clear subagent_handoffs on new user turn alongside the other per-turn state fields (recent_agent_calls, step_results, compare_outputs, etc.). Previously handoffs from prior turns leaked into the new context.

Performance:
- supervisor_agent.py synthesis_hitl_should_continue: skip progressive_synthesizer for simple/trivial graph_complexity. Short responses gained no benefit from incremental synthesis but paid its full latency cost.

Tuning:
- supervisor_constants.py: lower _LOOP_GUARD_MAX_CONSECUTIVE from 12 to 4. The threshold of 12 was unreachable given _MAX_AGENT_HOPS_PER_TURN=3 and _MAX_TOOL_CALLS_PER_TURN=12, making the guard ineffective.

Cleanup:
- supervisor_pipeline_prompts.py: remove the "For mixade fragor: skapa parallella steg" line from DEFAULT_SUPERVISOR_PLANNER_PROMPT. Mixed-domain planning is now handled exclusively by DEFAULT_SUPERVISOR_MULTI_DOMAIN_PLANNER_PROMPT; the duplicate instruction was confusing and could trigger parallel-step generation on non-mixed queries.
- smart_critic.py: remove the unused `_ = latest_user_query` placeholder line.

https://claude.ai/code/session_01FdgVNMMbQaapyXLm1PHMuC

<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing